### PR TITLE
name key for port in services accesible via virtual service

### DIFF
--- a/common/centraldashboard/base/service.yaml
+++ b/common/centraldashboard/base/service.yaml
@@ -15,7 +15,8 @@ metadata:
   name: centraldashboard
 spec:
   ports:
-  - port: 80
+  - name: http
+    port: 80
     protocol: TCP
     targetPort: 8082
   selector:

--- a/katib/katib-controller/base/katib-ui-service.yaml
+++ b/katib/katib-controller/base/katib-ui-service.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 80
+    - name: http
+      port: 80
       protocol: TCP
       name: ui
       targetPort: 8080

--- a/pipeline/pipelines-ui/base/service.yaml
+++ b/pipeline/pipelines-ui/base/service.yaml
@@ -7,7 +7,8 @@ metadata:
     app: ml-pipeline-ui
 spec:
   ports:
-  - port: 80
+  - name: http
+    port: 80
     targetPort: 3000
   selector:
     app: ml-pipeline-ui
@@ -20,7 +21,8 @@ metadata:
     app: ml-pipeline-tensorboard-ui
 spec:
   ports:
-  - port: 80
+  - name: http
+    port: 80
     targetPort: 3000
   selector:
     app: ml-pipeline-tensorboard-ui


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/manifests/issues/1602

**Description of your changes:**
added name key to ports in service spec for components accessible via istio virtual service
